### PR TITLE
Revert "add wayland socket"

### DIFF
--- a/codes.merritt.Nyrna.yml
+++ b/codes.merritt.Nyrna.yml
@@ -10,8 +10,7 @@ command: nyrna
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
   - --device=dri
   - --socket=pulseaudio
   - --share=network


### PR DESCRIPTION
This reverts commit 5c2b0c1316bfef4ddee7f4d2fba553351cf850de.

Using Wayland socket breaks the legacy keybindings. Will have to wait until migration to the global shortcuts portal.